### PR TITLE
Fix SeedFinder exception when Royalty DLC is not installed

### DIFF
--- a/Source/SeedFinder.cs
+++ b/Source/SeedFinder.cs
@@ -608,7 +608,9 @@ public class SeedFinderController : ModBase {
     internal void startFinding() {
         isSeedFinding = true;
 
-        ThingDefOf.Plant_TreeAnima.graphicData.drawSize *= 2.5f;
+        if (ModLister.RoyaltyInstalled) {
+            ThingDefOf.Plant_TreeAnima.graphicData.drawSize *= 2.5f;
+        }
 
         visitNextMap();
     }
@@ -616,7 +618,9 @@ public class SeedFinderController : ModBase {
     internal void stopFinding() {
         reset();
 
-        ThingDefOf.Plant_TreeAnima.graphicData.drawSize = origAnimaSize;
+        if (ModLister.RoyaltyInstalled) {
+            ThingDefOf.Plant_TreeAnima.graphicData.drawSize = origAnimaSize;
+        }
     }
 
     public override void Initialize() {
@@ -675,22 +679,24 @@ public class SeedFinderController : ModBase {
 
         filterParams.stoneScroll = new Vector2(0, 0);
 
-        origAnimaSize = ThingDefOf.Plant_TreeAnima.graphicData.drawSize;
+        if (ModLister.RoyaltyInstalled) {
+            origAnimaSize = ThingDefOf.Plant_TreeAnima.graphicData.drawSize;
 
-        foreach (var animaComp in ThingDefOf.Plant_TreeAnima.comps) {
-            var meditationComp = animaComp as CompProperties_MeditationFocus;
-            if (meditationComp != null) {
-                foreach (var offset in meditationComp.offsets) {
-                    var radiusOffset = offset as FocusStrengthOffset_ArtificialBuildings;
-                    if (radiusOffset != null) {
-                        animaRadius = radiusOffset.radius;
-                        break;
+            foreach (var animaComp in ThingDefOf.Plant_TreeAnima.comps) {
+                var meditationComp = animaComp as CompProperties_MeditationFocus;
+                if (meditationComp != null) {
+                    foreach (var offset in meditationComp.offsets) {
+                        var radiusOffset = offset as FocusStrengthOffset_ArtificialBuildings;
+                        if (radiusOffset != null) {
+                            animaRadius = radiusOffset.radius;
+                            break;
+                        }
                     }
                 }
-            }
 
-            if (animaRadius != -1f) {
-                break;
+                if (animaRadius != -1f) {
+                    break;
+                }
             }
         }
     }
@@ -846,8 +852,10 @@ public class SeedFinderController : ModBase {
         yield return new WaitForFixedUpdate();
 
         if (filterParams.highlightPOI) {
-            foreach (var animaThing in Find.CurrentMap.listerThings.ThingsOfDef(ThingDefOf.Plant_TreeAnima)) {
-                GenDraw.DrawRadiusRing(animaThing.Position, animaRadius, MeditationUtility.ArtificialBuildingRingColor);
+            if (ModLister.RoyaltyInstalled) {
+                foreach (var animaThing in Find.CurrentMap.listerThings.ThingsOfDef(ThingDefOf.Plant_TreeAnima)) {
+                    GenDraw.DrawRadiusRing(animaThing.Position, animaRadius, MeditationUtility.ArtificialBuildingRingColor);
+                }
             }
 
             foreach (var geyser in map.listerBuildings.AllBuildingsNonColonistOfDef(ThingDefOf.SteamGeyser)) {


### PR DESCRIPTION
Fixes `[HugsLib][ERR] SeedFinder caused an exception during LoadReloadInitialize`. In pure vanilla with no other mods or DLC, this issue was being caused by references to the Anima tree which don't exist.

Can be verified by toggling `Options -> Dev -> Simulate not owning Royalty` and testing the seed finder.

Note: I'm not a Rimworld modder so I'm not sure if this change is ideal, it's what I managed to get working after a few minutes. I thought I'd contribute my fix as I and a many others don't have the Royalty DLC making this mod unusable without it.